### PR TITLE
Rename class to className

### DIFF
--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -7,7 +7,7 @@ function Home() {
 
   return (
     <div className="mt-4 space-y-8">
-       <p class="text-neutral"> 👋 Hi {falcon.data.user.username}</p>
+       <p className="text-neutral"> 👋 Hi {falcon.data.user.username}</p>
        <Link useFalconNavigation={true} to="/crowdscore">Crowdscore</Link>
     </div>
   );


### PR DESCRIPTION
In React, the 'class' attribute should be replaced with 'className' to properly apply CSS classes.