### PR TITLE
fix: use navigation.navigateTo instead of onClick

### DIFF
--- a/src/components/link.js
+++ b/src/components/link.js
@@ -1,18 +1,33 @@
 import React, { useContext } from "react";
-import {  Link as ReactRouterLink } from "react-router-dom";
+import { Link as ReactRouterLink } from "react-router-dom";
 import { FalconApiContext } from "../contexts/falcon-api-context.js";
 
-function Link({ children, useFalconNavigation = false, to }) {
-  const { navigation } = useContext(FalconApiContext);
+function Link({
+  children,
+  useFalconNavigation = false,
+  to,
+  openInNewTab = false,
+}) {
+  const { falcon, navigation } = useContext(FalconApiContext);
+  const absolutePath = falcon.bridge.targetOrigin.concat(to);
 
+  const onClick = (e) => {
+    e.preventDefault();
+    navigation?.navigateTo({
+      path: to,
+      type: "falcon",
+      target: openInNewTab ? "_blank" : "_self",
+    });
+  };
   if (useFalconNavigation) {
     return (
-      <a onClick={navigation.onClick} href={to}>{children}</a>
-    )
+      <a onClick={onClick} href={absolutePath}>
+        {children}
+      </a>
+    );
   }
 
-  return <ReactRouterLink to={to}>{children}</ReactRouterLink>
-   
+  return <ReactRouterLink to={to}>{children}</ReactRouterLink>;
 }
 
 export { Link };


### PR DESCRIPTION
This PR updates the Link component in the Blueprint to use the `navigateTo` method  from the `navigation` api provided by foundry-js.   This better supports internal page/extension routing as well as routing to urls within Falcon Console.