### PR TITLE
Fix Vite build for Foundry sandboxed iframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,28 @@ Included in this blueprint are some common css and React components you can use 
 
 ## Routing
 
-This blueprint provides a [Link](/src/components/link.js) component to help with routing in your Extension or Page and within Falcon Console.
+This blueprint provides a [Link](/src/components/link.jsx) component to help with routing in your Extension or Page and within Falcon Console.
 
-The `<Link>` component accepts two props:
+The `<Link>` component accepts these props:
 
 - `to` - the path to navigate to
 - `useFalconNavigation` - a boolean value indicating whether or not a link click will update the Falcon Console url.  Defaults to `false`
+- `openInNewTab` - a boolean value indicating whether the link should open in a new tab.  Defaults to `false`
 
 Setting `useFalconNavigation` to `true` will send the user to a new location within Falcon Console (this changes the Falcon Console url in the user's browser)
 
 By default `useFalconNavigation` is set to `false` and React Router (included in this blueprint) will handle user navigation and UI changes within your app.
 
-Usage of the `<Link>` component can be seen in the [home](/src/routes/home.js) and [navigation](/src/components/navigation.js) components.
+Usage of the `<Link>` component can be seen in the [home](/src/routes/home.jsx) and [navigation](/src/components/navigation.jsx) components.
 
-```js
+```jsx
 import { Link } from '../components/link';
 
-// navigates to https://falcon.crowdstrike.com/crowdscore
-<Link useFalconNavigation={true} to="/crowdscore">Crowdscore</Link>
+// navigates to https://falcon.crowdstrike.com/activity
+<Link useFalconNavigation={true} to="/activity">Activity Dashboard</Link>
 
-// navigates to an /about route within your Extension or Page 
-<Link to="/about">Crowdscore</Link>
+// navigates to an /about route within your Extension or Page
+<Link to="/about">About</Link>
 ```
 
 ## Building your app

--- a/src/routes/home.jsx
+++ b/src/routes/home.jsx
@@ -8,7 +8,7 @@ function Home() {
   return (
     <div className="mt-4 space-y-8">
        <p className="text-neutral"> 👋 Hi {falcon.data.user.username}</p>
-       <Link useFalconNavigation={true} to="/crowdscore">Crowdscore</Link>
+       <Link useFalconNavigation={true} to="/activity">Activity Dashboard</Link>
     </div>
   );
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,18 @@
 import react from '@vitejs/plugin-react-swc'
 
+const noAttr = () => ({
+  name: 'no-attribute',
+  transformIndexHtml(html) {
+    return html.replace(/ crossorigin/g, '')
+  }
+})
+
 /** @type {import('vite').UserConfig} */
 export default {
   plugins: [
-    react()
+    react(),
+    noAttr()
   ],
-  root: 'src'
+  root: 'src',
+  base: './'
 };

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react-swc'
 const noAttr = () => ({
   name: 'no-attribute',
   transformIndexHtml(html) {
-    return html.replace(/ crossorigin/g, '')
+    return html.replace(/ crossorigin(?:="[^"]*")?/g, '')
   }
 })
 


### PR DESCRIPTION
The Rollup-to-Vite migration (commit a3df03a, Sep 2025) introduced two issues that cause the blueprint to render as a blank page when deployed to Falcon Foundry:

1. **`crossorigin` attribute** — Vite adds `crossorigin` to `<script>` and `<link>` tags in the build output. Foundry UI runs inside sandboxed iframes where the origin is `null`, so `crossorigin` triggers CORS failures.

2. **Absolute asset paths** — Vite defaults to `base: '/'`, producing paths like `/assets/index.js`. Inside the sandboxed iframe, absolute paths resolve to the wrong domain.

The fix adds a `noAttr()` Vite plugin to strip `crossorigin` attributes and sets `base: './'` for relative asset paths. Both changes are standard patterns used across Foundry sample apps.

**Before** (broken — deploys but renders blank):
```html
<script type="module" crossorigin src="/assets/index-B47Vzys5.js"></script>
<link rel="stylesheet" crossorigin href="/assets/index-CWs4lu1w.css">
```

**After** (working):
```html
<script type="module" src="./assets/index-B47Vzys5.js"></script>
<link rel="stylesheet" href="./assets/index-CWs4lu1w.css">
```

Also updates the README to fix stale `.js` file references (now `.jsx` after the Vite migration), documents the `openInNewTab` prop on the Link component, and replaces the deprecated `/crowdscore` example link with `/activity`.

Tested by deploying, releasing, installing, and verifying rendering for both UI pages and extensions in the Falcon console (us-2).