### PR TITLE
Fix navigation useMemo to use React state as dependency

### DIFF
--- a/src/contexts/falcon-api-context.js
+++ b/src/contexts/falcon-api-context.js
@@ -6,7 +6,7 @@ const FalconApiContext = createContext(null);
 function useFalconApiContext() {
   const [isInitialized, setIsInitialized] = useState(false);
   const falcon = useMemo(() => new FalconApi(), []);
-  const navigation = useMemo(() => falcon.isConnected ? falcon.navigation : undefined, [falcon.isConnected]);
+  const navigation = useMemo(() => isInitialized ? falcon.navigation : undefined, [isInitialized]);
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
The `navigation` useMemo uses `falcon.isConnected` as a dependency, but this is a plain object property, not React state. It works incidentally because `setIsInitialized(true)` triggers a re-render, but the dependency array is semantically incorrect.

This fix replaces `falcon.isConnected` with `isInitialized` (React state) as the dependency, making the reactive chain explicit and correct.

Identified via automated eval runs against the Foundry skills plugin, where the LLM judge flagged this pattern across 5+ generated apps as a timing bug.

Fixes #131